### PR TITLE
Restore filter field Enter key behaviour from v1

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutTableViewWindow.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutTableViewWindow.cs
@@ -275,7 +275,10 @@ internal sealed class OutTableViewWindow : Runnable<HashSet<int>>
         shortcuts.Add(_rowsShortcut);
 
         if (_applicationData.OutputMode != OutputModeOption.None)
-            shortcuts.Add(new Shortcut(Key.Enter, "Accept", null));
+            shortcuts.Add(new Shortcut(Key.Enter, "Accept", () =>
+            {
+                if (MostFocused == _filterField) _tableView!.SetFocus();
+            }));
 
         if (_applicationData.OutputMode == OutputModeOption.Multiple)
             shortcuts.Add(new Shortcut(Key.A.WithCtrl, "Sel. All", () => _tableView?.SelectAll()));


### PR DESCRIPTION
Not sure if you really want PR-inception here, but I noticed this during my testing.

Previously pressing the "Enter" key while in the filter field moved focus to the listvew. This adds that functionality to the new tableview version